### PR TITLE
Removed color of JoystickView parent Container

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -23,7 +23,6 @@ class HomePage extends StatelessWidget {
         title: Text('Control Pad Example'),
       ),
       body: Container(
-        color: Colors.white,
         child: JoystickView(),
       ),
     );


### PR DESCRIPTION
Removed color parameter for Container widget containing child = JoystickView

Reason: Explicitly specifying white color to the parent Container widget is not required. This results in color of the Container being transparent which is expected by default. So when changing the Scaffold color to any other color say black, the square Container area around the JoystickView should inherit the color of the parent widget. 

This just makes the example code cleaner.